### PR TITLE
Refactor integration base classes

### DIFF
--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -1,4 +1,5 @@
 from .base import BaseIntegration, IntegrationError
+from .project_management import ProjectManagementIntegration
 from .motion import MotionIntegration
 
-__all__ = ["BaseIntegration", "IntegrationError", "MotionIntegration"]
+__all__ = ["BaseIntegration", "ProjectManagementIntegration", "IntegrationError", "MotionIntegration"]

--- a/src/integrations/base.py
+++ b/src/integrations/base.py
@@ -1,11 +1,10 @@
 """Base integration class for all external services"""
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Optional
-from datetime import datetime
+from typing import Any, Dict, List
 import logging
 
-from ..models import Project, Task, User, IntegrationConfig
+from ..models import IntegrationConfig, User
 from ..storage import DeltaManager
 
 
@@ -14,182 +13,42 @@ logger = logging.getLogger(__name__)
 
 class IntegrationError(Exception):
     """Base exception for integration errors"""
+
     pass
 
 
 class BaseIntegration(ABC):
     """Abstract base class for all integrations"""
-    
+
     def __init__(self, config: IntegrationConfig, delta_manager: DeltaManager):
         self.config = config
         self.delta = delta_manager
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
-    
+
     @abstractmethod
     def validate_config(self) -> bool:
         """Validate the integration configuration"""
         pass
-    
+
     @abstractmethod
     def test_connection(self) -> bool:
         """Test the connection to the external service"""
         pass
-    
-    # Project operations
-    @abstractmethod
-    def create_project(self, project: Project) -> Dict[str, Any]:
-        """Create a project in the external service"""
-        pass
-    
-    @abstractmethod
-    def update_project(self, project_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
-        """Update a project in the external service"""
-        pass
-    
-    @abstractmethod
-    def get_project(self, external_id: str) -> Optional[Dict[str, Any]]:
-        """Get a project from the external service"""
-        pass
-    
-    @abstractmethod
-    def list_projects(self, filters: Dict[str, Any] = None) -> List[Dict[str, Any]]:
-        """List projects from the external service"""
-        pass
-    
-    # Task operations
-    @abstractmethod
-    def create_task(self, task: Task) -> Dict[str, Any]:
-        """Create a task in the external service"""
-        pass
-    
-    @abstractmethod
-    def update_task(self, task_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
-        """Update a task in the external service"""
-        pass
-    
-    @abstractmethod
-    def get_task(self, external_id: str) -> Optional[Dict[str, Any]]:
-        """Get a task from the external service"""
-        pass
-    
-    @abstractmethod
-    def list_tasks(self, project_id: Optional[str] = None, filters: Dict[str, Any] = None) -> List[Dict[str, Any]]:
-        """List tasks from the external service"""
-        pass
-    
+
     # User operations
     @abstractmethod
     def get_current_user(self) -> Dict[str, Any]:
         """Get the current authenticated user"""
         pass
-    
+
     @abstractmethod
     def list_users(self) -> List[Dict[str, Any]]:
         """List users from the external service"""
         pass
-    
-    # Sync operations
-    def sync_projects(self, direction: str = "bidirectional") -> Dict[str, Any]:
-        """Sync projects between local and external service"""
-        sync_stats = {
-            "projects_created_local": 0,
-            "projects_updated_local": 0,
-            "projects_created_external": 0,
-            "projects_updated_external": 0,
-            "errors": []
-        }
-        
-        try:
-            if direction in ["pull", "bidirectional"]:
-                # Pull from external to local
-                external_projects = self.list_projects()
-                for ext_project in external_projects:
-                    try:
-                        local_project = self._find_local_project_by_external_id(ext_project["id"])
-                        if local_project:
-                            # Update existing
-                            updates = self._map_external_project_to_updates(ext_project)
-                            self.delta.update_project(local_project["id"], updates)
-                            sync_stats["projects_updated_local"] += 1
-                        else:
-                            # Create new
-                            project_data = self._map_external_project_to_local(ext_project)
-                            self.delta.create_project(project_data, "sync_user")
-                            sync_stats["projects_created_local"] += 1
-                    except Exception as e:
-                        self.logger.error(f"Error syncing project {ext_project.get('id')}: {e}")
-                        sync_stats["errors"].append(str(e))
-            
-            if direction in ["push", "bidirectional"]:
-                # Push from local to external
-                local_projects = self.delta.get_projects()
-                for local_project in local_projects:
-                    try:
-                        ext_id = self._get_external_project_id(local_project)
-                        if ext_id:
-                            # Update existing
-                            updates = self._map_local_project_to_external_updates(local_project)
-                            self.update_project(ext_id, updates)
-                            sync_stats["projects_updated_external"] += 1
-                        else:
-                            # Create new
-                            ext_data = self.create_project(Project(**local_project))
-                            # Update local with external ID
-                            self.delta.update_project(local_project["id"], {
-                                f"{self.integration_type}_project_id": ext_data["id"]
-                            })
-                            sync_stats["projects_created_external"] += 1
-                    except Exception as e:
-                        self.logger.error(f"Error pushing project {local_project.get('id')}: {e}")
-                        sync_stats["errors"].append(str(e))
-        
-        except Exception as e:
-            self.logger.error(f"Sync failed: {e}")
-            sync_stats["errors"].append(f"Sync failed: {str(e)}")
-        
-        return sync_stats
-    
-    def sync_tasks(self, project_id: Optional[str] = None, direction: str = "bidirectional") -> Dict[str, Any]:
-        """Sync tasks between local and external service"""
-        # Similar implementation to sync_projects
-        sync_stats = {
-            "tasks_created_local": 0,
-            "tasks_updated_local": 0,
-            "tasks_created_external": 0,
-            "tasks_updated_external": 0,
-            "errors": []
-        }
-        
-        # Implementation would follow similar pattern to sync_projects
-        return sync_stats
-    
+
     # Helper methods to be implemented by subclasses
     @property
     @abstractmethod
     def integration_type(self) -> str:
         """Return the integration type identifier"""
         pass
-    
-    @abstractmethod
-    def _map_external_project_to_local(self, external_project: Dict[str, Any]) -> Dict[str, Any]:
-        """Map external project data to local format"""
-        pass
-    
-    @abstractmethod
-    def _map_external_project_to_updates(self, external_project: Dict[str, Any]) -> Dict[str, Any]:
-        """Map external project data to update fields"""
-        pass
-    
-    @abstractmethod
-    def _map_local_project_to_external_updates(self, local_project: Dict[str, Any]) -> Dict[str, Any]:
-        """Map local project data to external update format"""
-        pass
-    
-    def _find_local_project_by_external_id(self, external_id: str) -> Optional[Dict[str, Any]]:
-        """Find a local project by its external ID"""
-        projects = self.delta.get_projects({f"{self.integration_type}_project_id": external_id})
-        return projects[0] if projects else None
-    
-    def _get_external_project_id(self, local_project: Dict[str, Any]) -> Optional[str]:
-        """Get the external ID for a local project"""
-        return local_project.get(f"{self.integration_type}_project_id")

--- a/src/integrations/motion.py
+++ b/src/integrations/motion.py
@@ -5,72 +5,59 @@ from typing import Dict, Any, List, Optional
 from datetime import datetime, date
 import logging
 
-from .base import BaseIntegration, IntegrationError
+from .base import IntegrationError
+from .project_management import ProjectManagementIntegration
 from ..models import Project, Task, ProjectStatus, TaskStatus, TaskPriority
 
 
 logger = logging.getLogger(__name__)
 
 
-class MotionIntegration(BaseIntegration):
+class MotionIntegration(ProjectManagementIntegration):
     """Integration with Motion task management"""
-    
+
     BASE_URL = "https://api.usemotion.com/v1"
-    
+
     @property
     def integration_type(self) -> str:
         return "motion"
-    
+
     def _get_headers(self) -> Dict[str, str]:
         """Get API headers"""
         api_key = self.config.api_key.get_secret_value() if self.config.api_key else None
         if not api_key:
             raise IntegrationError("Motion API key not configured")
-        
-        return {
-            "X-API-Key": api_key,
-            "Accept": "application/json",
-            "Content-Type": "application/json"
-        }
-    
+
+        return {"X-API-Key": api_key, "Accept": "application/json", "Content-Type": "application/json"}
+
     def validate_config(self) -> bool:
         """Validate Motion configuration"""
         if not self.config.api_key:
             raise IntegrationError("Motion API key is required")
         return True
-    
+
     def test_connection(self) -> bool:
         """Test Motion API connection"""
         try:
-            response = requests.get(
-                f"{self.BASE_URL}/users/me",
-                headers=self._get_headers(),
-                timeout=10
-            )
+            response = requests.get(f"{self.BASE_URL}/users/me", headers=self._get_headers(), timeout=10)
             return response.status_code == 200
         except Exception as e:
             logger.error(f"Motion connection test failed: {e}")
             return False
-    
+
     # User operations
     def get_current_user(self) -> Dict[str, Any]:
         """Get current Motion user"""
-        response = requests.get(
-            f"{self.BASE_URL}/users/me",
-            headers=self._get_headers()
-        )
+        response = requests.get(f"{self.BASE_URL}/users/me", headers=self._get_headers())
         response.raise_for_status()
         return response.json()
-    
+
     def list_users(self) -> List[Dict[str, Any]]:
         """List Motion workspace users"""
-        response = requests.get(
-            f"{self.BASE_URL}/users",
-            headers=self._get_headers()
-        )
+        response = requests.get(f"{self.BASE_URL}/users", headers=self._get_headers())
         response.raise_for_status()
         return response.json().get("users", [])
-    
+
     # Project operations
     def create_project(self, project: Project) -> Dict[str, Any]:
         """Create a project in Motion"""
@@ -79,21 +66,17 @@ class MotionIntegration(BaseIntegration):
             "description": project.description,
             "dueDate": project.due_date.isoformat() if project.due_date else None,
             "status": self._map_project_status_to_motion(project.status),
-            "workspaceId": self.config.workspace_id
+            "workspaceId": self.config.workspace_id,
         }
-        
-        response = requests.post(
-            f"{self.BASE_URL}/projects",
-            json=data,
-            headers=self._get_headers()
-        )
+
+        response = requests.post(f"{self.BASE_URL}/projects", json=data, headers=self._get_headers())
         response.raise_for_status()
         return response.json()
-    
+
     def update_project(self, project_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
         """Update a Motion project"""
         motion_updates = {}
-        
+
         if "name" in updates:
             motion_updates["name"] = updates["name"]
         if "description" in updates:
@@ -102,44 +85,35 @@ class MotionIntegration(BaseIntegration):
             motion_updates["dueDate"] = updates["due_date"].isoformat() if updates["due_date"] else None
         if "status" in updates:
             motion_updates["status"] = self._map_project_status_to_motion(updates["status"])
-        
+
         response = requests.patch(
-            f"{self.BASE_URL}/projects/{project_id}",
-            json=motion_updates,
-            headers=self._get_headers()
+            f"{self.BASE_URL}/projects/{project_id}", json=motion_updates, headers=self._get_headers()
         )
         response.raise_for_status()
         return response.json()
-    
+
     def get_project(self, external_id: str) -> Optional[Dict[str, Any]]:
         """Get a Motion project"""
         try:
-            response = requests.get(
-                f"{self.BASE_URL}/projects/{external_id}",
-                headers=self._get_headers()
-            )
+            response = requests.get(f"{self.BASE_URL}/projects/{external_id}", headers=self._get_headers())
             response.raise_for_status()
             return response.json()
         except requests.HTTPError as e:
             if e.response.status_code == 404:
                 return None
             raise
-    
+
     def list_projects(self, filters: Dict[str, Any] = None) -> List[Dict[str, Any]]:
         """List Motion projects"""
         params = {}
         if filters:
             if "status" in filters:
                 params["status"] = filters["status"]
-        
-        response = requests.get(
-            f"{self.BASE_URL}/projects",
-            params=params,
-            headers=self._get_headers()
-        )
+
+        response = requests.get(f"{self.BASE_URL}/projects", params=params, headers=self._get_headers())
         response.raise_for_status()
         return response.json().get("projects", [])
-    
+
     # Task operations
     def create_task(self, task: Task) -> Dict[str, Any]:
         """Create a task in Motion"""
@@ -147,7 +121,7 @@ class MotionIntegration(BaseIntegration):
         project = self.delta.get_project(task.project_id)
         if not project or not project.get("motion_project_id"):
             raise IntegrationError(f"Project {task.project_id} not synced with Motion")
-        
+
         data = {
             "name": task.title,
             "description": task.description,
@@ -157,24 +131,20 @@ class MotionIntegration(BaseIntegration):
             "priority": self._map_task_priority_to_motion(task.priority),
             "status": self._map_task_status_to_motion(task.status),
             "assigneeId": self._get_motion_user_id(task.assignee) if task.assignee else None,
-            "labels": task.labels
+            "labels": task.labels,
         }
-        
+
         # Remove None values
         data = {k: v for k, v in data.items() if v is not None}
-        
-        response = requests.post(
-            f"{self.BASE_URL}/tasks",
-            json=data,
-            headers=self._get_headers()
-        )
+
+        response = requests.post(f"{self.BASE_URL}/tasks", json=data, headers=self._get_headers())
         response.raise_for_status()
         return response.json()
-    
+
     def update_task(self, task_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
         """Update a Motion task"""
         motion_updates = {}
-        
+
         if "title" in updates:
             motion_updates["name"] = updates["title"]
         if "description" in updates:
@@ -188,54 +158,45 @@ class MotionIntegration(BaseIntegration):
         if "status" in updates:
             motion_updates["status"] = self._map_task_status_to_motion(updates["status"])
         if "assignee" in updates:
-            motion_updates["assigneeId"] = self._get_motion_user_id(updates["assignee"]) if updates["assignee"] else None
-        
-        response = requests.patch(
-            f"{self.BASE_URL}/tasks/{task_id}",
-            json=motion_updates,
-            headers=self._get_headers()
-        )
+            motion_updates["assigneeId"] = (
+                self._get_motion_user_id(updates["assignee"]) if updates["assignee"] else None
+            )
+
+        response = requests.patch(f"{self.BASE_URL}/tasks/{task_id}", json=motion_updates, headers=self._get_headers())
         response.raise_for_status()
         return response.json()
-    
+
     def get_task(self, external_id: str) -> Optional[Dict[str, Any]]:
         """Get a Motion task"""
         try:
-            response = requests.get(
-                f"{self.BASE_URL}/tasks/{external_id}",
-                headers=self._get_headers()
-            )
+            response = requests.get(f"{self.BASE_URL}/tasks/{external_id}", headers=self._get_headers())
             response.raise_for_status()
             return response.json()
         except requests.HTTPError as e:
             if e.response.status_code == 404:
                 return None
             raise
-    
+
     def list_tasks(self, project_id: Optional[str] = None, filters: Dict[str, Any] = None) -> List[Dict[str, Any]]:
         """List Motion tasks"""
         params = {}
-        
+
         if project_id:
             # Get Motion project ID
             project = self.delta.get_project(project_id)
             if project and project.get("motion_project_id"):
                 params["projectId"] = project["motion_project_id"]
-        
+
         if filters:
             if "status" in filters:
                 params["status"] = filters["status"]
             if "assignee" in filters:
                 params["assigneeId"] = self._get_motion_user_id(filters["assignee"])
-        
-        response = requests.get(
-            f"{self.BASE_URL}/tasks",
-            params=params,
-            headers=self._get_headers()
-        )
+
+        response = requests.get(f"{self.BASE_URL}/tasks", params=params, headers=self._get_headers())
         response.raise_for_status()
         return response.json().get("tasks", [])
-    
+
     # Mapping methods
     def _map_project_status_to_motion(self, status: ProjectStatus) -> str:
         """Map internal project status to Motion status"""
@@ -244,10 +205,10 @@ class MotionIntegration(BaseIntegration):
             ProjectStatus.ACTIVE: "IN_PROGRESS",
             ProjectStatus.ON_HOLD: "ON_HOLD",
             ProjectStatus.COMPLETED: "COMPLETED",
-            ProjectStatus.ARCHIVED: "ARCHIVED"
+            ProjectStatus.ARCHIVED: "ARCHIVED",
         }
         return mapping.get(status, "PLANNING")
-    
+
     def _map_motion_project_status(self, motion_status: str) -> ProjectStatus:
         """Map Motion project status to internal status"""
         mapping = {
@@ -255,10 +216,10 @@ class MotionIntegration(BaseIntegration):
             "IN_PROGRESS": ProjectStatus.ACTIVE,
             "ON_HOLD": ProjectStatus.ON_HOLD,
             "COMPLETED": ProjectStatus.COMPLETED,
-            "ARCHIVED": ProjectStatus.ARCHIVED
+            "ARCHIVED": ProjectStatus.ARCHIVED,
         }
         return mapping.get(motion_status, ProjectStatus.PLANNING)
-    
+
     def _map_task_status_to_motion(self, status: TaskStatus) -> str:
         """Map internal task status to Motion status"""
         mapping = {
@@ -267,10 +228,10 @@ class MotionIntegration(BaseIntegration):
             TaskStatus.BLOCKED: "BLOCKED",
             TaskStatus.IN_REVIEW: "IN_REVIEW",
             TaskStatus.COMPLETED: "COMPLETED",
-            TaskStatus.CANCELLED: "CANCELLED"
+            TaskStatus.CANCELLED: "CANCELLED",
         }
         return mapping.get(status, "TODO")
-    
+
     def _map_motion_task_status(self, motion_status: str) -> TaskStatus:
         """Map Motion task status to internal status"""
         mapping = {
@@ -279,10 +240,10 @@ class MotionIntegration(BaseIntegration):
             "BLOCKED": TaskStatus.BLOCKED,
             "IN_REVIEW": TaskStatus.IN_REVIEW,
             "COMPLETED": TaskStatus.COMPLETED,
-            "CANCELLED": TaskStatus.CANCELLED
+            "CANCELLED": TaskStatus.CANCELLED,
         }
         return mapping.get(motion_status, TaskStatus.TODO)
-    
+
     def _map_task_priority_to_motion(self, priority: TaskPriority) -> str:
         """Map internal priority to Motion priority"""
         mapping = {
@@ -290,38 +251,38 @@ class MotionIntegration(BaseIntegration):
             TaskPriority.HIGH: "HIGH",
             TaskPriority.MEDIUM: "MEDIUM",
             TaskPriority.LOW: "LOW",
-            TaskPriority.BACKLOG: "LOW"
+            TaskPriority.BACKLOG: "LOW",
         }
         return mapping.get(priority, "MEDIUM")
-    
+
     def _map_motion_task_priority(self, motion_priority: str) -> TaskPriority:
         """Map Motion priority to internal priority"""
         mapping = {
             "ASAP": TaskPriority.CRITICAL,
             "HIGH": TaskPriority.HIGH,
             "MEDIUM": TaskPriority.MEDIUM,
-            "LOW": TaskPriority.LOW
+            "LOW": TaskPriority.LOW,
         }
         return mapping.get(motion_priority, TaskPriority.MEDIUM)
-    
+
     def _get_motion_user_id(self, user_ref: str) -> Optional[str]:
         """Get Motion user ID from local user reference"""
         if not user_ref:
             return None
-        
+
         # Try to find user by ID or name
         user = self.delta.get_user(user_ref)
         if user and user.get("motion_user_id"):
             return user["motion_user_id"]
-        
+
         # Fallback: search by name in Motion users
         motion_users = self.list_users()
         for m_user in motion_users:
             if m_user.get("name") == user_ref or m_user.get("email") == user_ref:
                 return m_user["id"]
-        
+
         return None
-    
+
     def _map_external_project_to_local(self, external_project: Dict[str, Any]) -> Dict[str, Any]:
         """Map Motion project to local format"""
         return {
@@ -329,11 +290,15 @@ class MotionIntegration(BaseIntegration):
             "description": external_project.get("description"),
             "status": self._map_motion_project_status(external_project.get("status", "PLANNING")),
             "priority": 3,  # Default priority
-            "due_date": datetime.fromisoformat(external_project["dueDate"].replace("Z", "+00:00")).date() if external_project.get("dueDate") else None,
+            "due_date": (
+                datetime.fromisoformat(external_project["dueDate"].replace("Z", "+00:00")).date()
+                if external_project.get("dueDate")
+                else None
+            ),
             "motion_project_id": external_project["id"],
-            "tags": external_project.get("labels", [])
+            "tags": external_project.get("labels", []),
         }
-    
+
     def _map_external_project_to_updates(self, external_project: Dict[str, Any]) -> Dict[str, Any]:
         """Map Motion project to update fields"""
         updates = {
@@ -341,21 +306,25 @@ class MotionIntegration(BaseIntegration):
             "description": external_project.get("description"),
             "status": self._map_motion_project_status(external_project.get("status", "PLANNING")),
         }
-        
+
         if external_project.get("dueDate"):
             updates["due_date"] = datetime.fromisoformat(external_project["dueDate"].replace("Z", "+00:00")).date()
-        
+
         return updates
-    
+
     def _map_local_project_to_external_updates(self, local_project: Dict[str, Any]) -> Dict[str, Any]:
         """Map local project to Motion update format"""
         updates = {
             "name": local_project["name"],
             "description": local_project.get("description"),
-            "status": self._map_project_status_to_motion(ProjectStatus(local_project["status"]))
+            "status": self._map_project_status_to_motion(ProjectStatus(local_project["status"])),
         }
-        
+
         if local_project.get("due_date"):
-            updates["dueDate"] = local_project["due_date"].isoformat() if isinstance(local_project["due_date"], date) else local_project["due_date"]
-        
+            updates["dueDate"] = (
+                local_project["due_date"].isoformat()
+                if isinstance(local_project["due_date"], date)
+                else local_project["due_date"]
+            )
+
         return updates

--- a/src/integrations/project_management.py
+++ b/src/integrations/project_management.py
@@ -1,0 +1,154 @@
+"""Base classes for integrations providing project and task management."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+from datetime import datetime
+
+from .base import BaseIntegration
+from ..models import Project, Task
+
+
+class ProjectManagementIntegration(BaseIntegration, ABC):
+    """Base class for integrations that manage projects and tasks."""
+
+    # Project operations
+    @abstractmethod
+    def create_project(self, project: Project) -> Dict[str, Any]:
+        """Create a project in the external service"""
+        pass
+
+    @abstractmethod
+    def update_project(self, project_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a project in the external service"""
+        pass
+
+    @abstractmethod
+    def get_project(self, external_id: str) -> Optional[Dict[str, Any]]:
+        """Get a project from the external service"""
+        pass
+
+    @abstractmethod
+    def list_projects(self, filters: Dict[str, Any] = None) -> List[Dict[str, Any]]:
+        """List projects from the external service"""
+        pass
+
+    # Task operations
+    @abstractmethod
+    def create_task(self, task: Task) -> Dict[str, Any]:
+        """Create a task in the external service"""
+        pass
+
+    @abstractmethod
+    def update_task(self, task_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a task in the external service"""
+        pass
+
+    @abstractmethod
+    def get_task(self, external_id: str) -> Optional[Dict[str, Any]]:
+        """Get a task from the external service"""
+        pass
+
+    @abstractmethod
+    def list_tasks(self, project_id: Optional[str] = None, filters: Dict[str, Any] = None) -> List[Dict[str, Any]]:
+        """List tasks from the external service"""
+        pass
+
+    # Sync operations
+    def sync_projects(self, direction: str = "bidirectional") -> Dict[str, Any]:
+        """Sync projects between local and external service"""
+        sync_stats = {
+            "projects_created_local": 0,
+            "projects_updated_local": 0,
+            "projects_created_external": 0,
+            "projects_updated_external": 0,
+            "errors": [],
+        }
+
+        try:
+            if direction in ["pull", "bidirectional"]:
+                # Pull from external to local
+                external_projects = self.list_projects()
+                for ext_project in external_projects:
+                    try:
+                        local_project = self._find_local_project_by_external_id(ext_project["id"])
+                        if local_project:
+                            # Update existing
+                            updates = self._map_external_project_to_updates(ext_project)
+                            self.delta.update_project(local_project["id"], updates)
+                            sync_stats["projects_updated_local"] += 1
+                        else:
+                            # Create new
+                            project_data = self._map_external_project_to_local(ext_project)
+                            self.delta.create_project(project_data, "sync_user")
+                            sync_stats["projects_created_local"] += 1
+                    except Exception as e:
+                        self.logger.error(f"Error syncing project {ext_project.get('id')}: {e}")
+                        sync_stats["errors"].append(str(e))
+
+            if direction in ["push", "bidirectional"]:
+                # Push from local to external
+                local_projects = self.delta.get_projects()
+                for local_project in local_projects:
+                    try:
+                        ext_id = self._get_external_project_id(local_project)
+                        if ext_id:
+                            # Update existing
+                            updates = self._map_local_project_to_external_updates(local_project)
+                            self.update_project(ext_id, updates)
+                            sync_stats["projects_updated_external"] += 1
+                        else:
+                            # Create new
+                            ext_data = self.create_project(Project(**local_project))
+                            # Update local with external ID
+                            self.delta.update_project(
+                                local_project["id"], {f"{self.integration_type}_project_id": ext_data["id"]}
+                            )
+                            sync_stats["projects_created_external"] += 1
+                    except Exception as e:
+                        self.logger.error(f"Error pushing project {local_project.get('id')}: {e}")
+                        sync_stats["errors"].append(str(e))
+
+        except Exception as e:
+            self.logger.error(f"Sync failed: {e}")
+            sync_stats["errors"].append(f"Sync failed: {str(e)}")
+
+        return sync_stats
+
+    def sync_tasks(self, project_id: Optional[str] = None, direction: str = "bidirectional") -> Dict[str, Any]:
+        """Sync tasks between local and external service"""
+        # Similar implementation to sync_projects
+        sync_stats = {
+            "tasks_created_local": 0,
+            "tasks_updated_local": 0,
+            "tasks_created_external": 0,
+            "tasks_updated_external": 0,
+            "errors": [],
+        }
+
+        # Implementation would follow similar pattern to sync_projects
+        return sync_stats
+
+    # Helper methods used during sync
+    @abstractmethod
+    def _map_external_project_to_local(self, external_project: Dict[str, Any]) -> Dict[str, Any]:
+        """Map external project data to local format"""
+        pass
+
+    @abstractmethod
+    def _map_external_project_to_updates(self, external_project: Dict[str, Any]) -> Dict[str, Any]:
+        """Map external project data to update fields"""
+        pass
+
+    @abstractmethod
+    def _map_local_project_to_external_updates(self, local_project: Dict[str, Any]) -> Dict[str, Any]:
+        """Map local project data to external update format"""
+        pass
+
+    def _find_local_project_by_external_id(self, external_id: str) -> Optional[Dict[str, Any]]:
+        """Find a local project by its external ID"""
+        projects = self.delta.get_projects({f"{self.integration_type}_project_id": external_id})
+        return projects[0] if projects else None
+
+    def _get_external_project_id(self, local_project: Dict[str, Any]) -> Optional[str]:
+        """Get the external ID for a local project"""
+        return local_project.get(f"{self.integration_type}_project_id")


### PR DESCRIPTION
## Summary
- move project/task methods to `ProjectManagementIntegration`
- keep `BaseIntegration` minimal
- update Motion integration to use new base class
- export new class in package

## Testing
- `black -q src/integrations/base.py src/integrations/project_management.py src/integrations/motion.py src/integrations/__init__.py`
- `flake8` *(fails: command not found)*
- `mypy src/integrations/base.py src/integrations/project_management.py src/integrations/motion.py src/integrations/__init__.py` *(fails: several import and typing errors)*

------
https://chatgpt.com/codex/tasks/task_b_6858731f9bd4832eaffed93a9a0d3748